### PR TITLE
Add Maven dependency information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Reporting statistics from Guava caches to CodaHale/Dropwizard Metrics.
 Based on a blog post by Deepak Sarda 
 http://antrix.net/posts/2014/codahale-metrics-guava-cache/
 
- 
+Installation
+------------
 
+The library `guava-metrics` is [available from Maven Central](http://search.maven.org/#search|ga|1|g%3A%22no.finn.guava-metrics%22%20a%3A%22guava-metrics%22).
+
+    <dependency>
+      <groupId>no.finn.guava-metrics</groupId>
+      <artifactId>guava-metrics</artifactId>
+      <version>1.2</version>
+    </dependency>
 


### PR DESCRIPTION
Java developers usually resolve dependencies by using their build tool. For that purpose they need the Maven dependency information. I added it to the readme because this document is shown on the project's start page.
