### PR TITLE
Allow renaming of metric fields.

### DIFF
--- a/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
+++ b/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
@@ -1,14 +1,14 @@
 package no.finn.metrics;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricSet;
 import com.google.common.cache.Cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.codahale.metrics.MetricRegistry.name;
 
 /**
  * Created by Henning Spjelkavik on 23.10.2014.
@@ -19,28 +19,107 @@ import com.google.common.cache.Cache;
  */
 
 public class GuavaCacheMetrics extends HashMap< String, Metric> implements MetricSet {
-    /** Metric names. */
-    private static String hitRateMetric = "hitRate";
-    private static String hitCountMetric = "hitCount";
-    private static String missCountMetric = "missCount";
-    private static String loadExceptionCountMetric = "loadExceptionCount";
-    private static String evictionCountMetric = "evictionCount";
+
+    public class Builder {
+        private String hitRateMetric = "hitRate";
+        private String hitCountMetric = "hitCount";
+        private String missCountMetric = "missCount";
+        private String loadExceptionCountMetric = "loadExceptionCount";
+        private String evictionCountMetric = "evictionCount";
+        private Class clzz = GuavaCacheMetrics.class;
+        private String cacheName = "cache";
+        final Cache cache;
+
+        Builder(final Cache cache) {
+            this.cache = cache;
+        }
+
+        public Builder withHitRateName(String name) {
+            hitRateMetric = name;
+            return this;
+        }
+
+        public Builder withHitCountName(String name) {
+            hitCountMetric = name;
+            return this;
+        }
+
+        public Builder withMissCountName(String name) {
+            missCountMetric = name;
+            return this;
+        }
+
+        public Builder withLoadExceptionCountName(String name) {
+            loadExceptionCountMetric = name;
+            return this;
+        }
+
+        public Builder withEvictionCountName(String name) {
+            evictionCountMetric = name;
+            return this;
+        }
+
+        public Builder forClass(Class clzz) {
+            this.clzz = clzz;
+            return this;
+        }
+
+        public Builder withCacheName(String cacheName) {
+            this.cacheName = cacheName;
+            return this;
+        }
+
+        public GuavaCacheMetrics build() {
+            GuavaCacheMetrics metrics = new GuavaCacheMetrics();
+
+            metrics.put( name( clzz, cacheName, hitRateMetric), new Gauge< Double >() {
+                @Override
+                public Double getValue() {
+                    return cache.stats().hitRate();
+                }
+            } );
+
+            metrics.put( name( clzz, cacheName, hitCountMetric), new Gauge< Long >() {
+                @Override
+                public Long getValue() {
+                    return cache.stats().hitCount();
+                }
+            } );
+
+            metrics.put( name( clzz, cacheName, missCountMetric), new Gauge< Long >() {
+                @Override
+                public Long getValue() {
+                    return cache.stats().missCount();
+                }
+            } );
+
+            metrics.put( name( clzz, cacheName, loadExceptionCountMetric), new Gauge< Long >() {
+                @Override
+                public Long getValue() {
+                    return cache.stats().loadExceptionCount();
+                }
+            } );
+
+            metrics.put( name( clzz, cacheName, evictionCountMetric ), new Gauge< Long >() {
+                @Override
+                public Long getValue() {
+                    return cache.stats().evictionCount();
+                }
+            } );
+
+            return metrics;
+        }
+    }
 
     /**
      * Rename metrics. Has global effect.
      */
-    public static void setMetricNames(String hitRateMetric,
-                                      String hitCountMetric,
-                                      String missCountMetric,
-                                      String loadExceptionCountMetric,
-                                      String evictionCountMetric
-    ) {
-        GuavaCacheMetrics.hitRateMetric = hitRateMetric;
-        GuavaCacheMetrics.hitCountMetric = hitCountMetric;
-        GuavaCacheMetrics.missCountMetric = missCountMetric;
-        GuavaCacheMetrics.loadExceptionCountMetric = loadExceptionCountMetric;
-        GuavaCacheMetrics.evictionCountMetric = evictionCountMetric;
-    }
+    private GuavaCacheMetrics() {}
+
+    /**
+     * Create new Builder.
+     */
+    public static Builder newBuilder(final Cache cache) { return (new GuavaCacheMetrics()).new Builder(cache); }
 
     /**
      * Wraps the provided Guava cache's statistics into Gauges suitable for reporting via Codahale Metrics
@@ -53,48 +132,7 @@ public class GuavaCacheMetrics extends HashMap< String, Metric> implements Metri
      * @return MetricSet suitable for registration with a MetricRegistry
      */
     public static MetricSet metricsFor( Class clzz, String cacheName, final Cache cache ) {
-
-        GuavaCacheMetrics metrics = new GuavaCacheMetrics();
-
-        metrics.put( name( clzz, cacheName, hitRateMetric), new Gauge< Double >() {
-            @Override
-            public Double getValue() {
-                return cache.stats().hitRate();
-            }
-        } );
-
-        metrics.put( name( clzz, cacheName, hitCountMetric), new Gauge< Long >() {
-            @Override
-            public Long getValue() {
-                return cache.stats().hitCount();
-            }
-        } );
-
-        metrics.put( name( clzz, cacheName, missCountMetric), new Gauge< Long >() {
-            @Override
-            public Long getValue() {
-                return cache.stats().missCount();
-            }
-        } );
-
-        metrics.put( name( clzz, cacheName, loadExceptionCountMetric), new Gauge< Long >() {
-            @Override
-            public Long getValue() {
-                return cache.stats().loadExceptionCount();
-            }
-        } );
-
-        metrics.put( name( clzz, cacheName, evictionCountMetric ), new Gauge< Long >() {
-            @Override
-            public Long getValue() {
-                return cache.stats().evictionCount();
-            }
-        } );
-
-        return metrics;
-    }
-
-    private GuavaCacheMetrics() {
+        return newBuilder(cache).withCacheName(cacheName).forClass(clzz).build();
     }
 
     @Override

--- a/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
+++ b/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
@@ -70,7 +70,7 @@ public class GuavaCacheMetrics extends HashMap< String, Metric> implements Metri
         }
 
         public GuavaCacheMetrics build() {
-            GuavaCacheMetrics metrics = new GuavaCacheMetrics();
+            GuavaCacheMetrics metrics = GuavaCacheMetrics.this;
 
             metrics.put( name( clzz, cacheName, hitRateMetric), new Gauge< Double >() {
                 @Override
@@ -119,7 +119,10 @@ public class GuavaCacheMetrics extends HashMap< String, Metric> implements Metri
     /**
      * Create new Builder.
      */
-    public static Builder newBuilder(final Cache cache) { return (new GuavaCacheMetrics()).new Builder(cache); }
+    public static Builder newBuilder(final Cache cache) {
+        GuavaCacheMetrics metrics = new GuavaCacheMetrics();
+        return metrics.new Builder(cache);
+    }
 
     /**
      * Wraps the provided Guava cache's statistics into Gauges suitable for reporting via Codahale Metrics

--- a/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
+++ b/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
@@ -19,6 +19,28 @@ import com.google.common.cache.Cache;
  */
 
 public class GuavaCacheMetrics extends HashMap< String, Metric> implements MetricSet {
+    /** Metric names. */
+    private static String hitRateMetric = "hitRate";
+    private static String hitCountMetric = "hitCount";
+    private static String missCountMetric = "missCount";
+    private static String loadExceptionCountMetric = "loadExceptionCount";
+    private static String evictionCountMetric = "evictionCount";
+
+    /**
+     * Rename metrics. Has global effect.
+     */
+    public static void setMetricNames(String hitRateMetric,
+                                      String hitCountMetric,
+                                      String missCountMetric,
+                                      String loadExceptionCountMetric,
+                                      String evictionCountMetric
+    ) {
+        GuavaCacheMetrics.hitRateMetric = hitRateMetric;
+        GuavaCacheMetrics.hitCountMetric = hitCountMetric;
+        GuavaCacheMetrics.missCountMetric = missCountMetric;
+        GuavaCacheMetrics.loadExceptionCountMetric = loadExceptionCountMetric;
+        GuavaCacheMetrics.evictionCountMetric = evictionCountMetric;
+    }
 
     /**
      * Wraps the provided Guava cache's statistics into Gauges suitable for reporting via Codahale Metrics
@@ -34,35 +56,35 @@ public class GuavaCacheMetrics extends HashMap< String, Metric> implements Metri
 
         GuavaCacheMetrics metrics = new GuavaCacheMetrics();
 
-        metrics.put( name( clzz, cacheName, "hitRate" ), new Gauge< Double >() {
+        metrics.put( name( clzz, cacheName, hitRateMetric), new Gauge< Double >() {
             @Override
             public Double getValue() {
                 return cache.stats().hitRate();
             }
         } );
 
-        metrics.put( name( clzz, cacheName, "hitCount" ), new Gauge< Long >() {
+        metrics.put( name( clzz, cacheName, hitCountMetric), new Gauge< Long >() {
             @Override
             public Long getValue() {
                 return cache.stats().hitCount();
             }
         } );
 
-        metrics.put( name( clzz, cacheName, "missCount" ), new Gauge< Long >() {
+        metrics.put( name( clzz, cacheName, missCountMetric), new Gauge< Long >() {
             @Override
             public Long getValue() {
                 return cache.stats().missCount();
             }
         } );
 
-        metrics.put( name( clzz, cacheName, "loadExceptionCount" ), new Gauge< Long >() {
+        metrics.put( name( clzz, cacheName, loadExceptionCountMetric), new Gauge< Long >() {
             @Override
             public Long getValue() {
                 return cache.stats().loadExceptionCount();
             }
         } );
 
-        metrics.put( name( clzz, cacheName, "evictionCount" ), new Gauge< Long >() {
+        metrics.put( name( clzz, cacheName, evictionCountMetric ), new Gauge< Long >() {
             @Override
             public Long getValue() {
                 return cache.stats().evictionCount();

--- a/src/test/groovy/no/finn/metrics/GuavaCacheMetricsTest.groovy
+++ b/src/test/groovy/no/finn/metrics/GuavaCacheMetricsTest.groovy
@@ -13,8 +13,16 @@ class GuavaCacheMetricsTest extends Specification {
 
         def cache = CacheBuilder.newBuilder().recordStats().build()
         def registry = new MetricRegistry()
-        GuavaCacheMetrics.setMetricNames("efficiency", "hits", "misses", "loadExceptions", "evictions")
-        registry.registerAll(GuavaCacheMetrics.metricsFor(GuavaCacheMetricsTest.class, "MyCache", cache))
+        def metrics = GuavaCacheMetrics.newBuilder(cache)
+            .withHitCountName("hits")
+            .withMissCountName("misses")
+            .withHitRateName("efficiency")
+            .withEvictionCountName("evictions")
+            .withLoadExceptionCountName("loadExceptions")
+            .withCacheName("MyCache")
+            .forClass(GuavaCacheMetricsTest.class)
+            .build()
+        registry.registerAll(metrics)
 
         when: "various read/write operations are performed on the cache"
 

--- a/src/test/groovy/no/finn/metrics/GuavaCacheMetricsTest.groovy
+++ b/src/test/groovy/no/finn/metrics/GuavaCacheMetricsTest.groovy
@@ -13,6 +13,7 @@ class GuavaCacheMetricsTest extends Specification {
 
         def cache = CacheBuilder.newBuilder().recordStats().build()
         def registry = new MetricRegistry()
+        GuavaCacheMetrics.setMetricNames("efficiency", "hits", "misses", "loadExceptions", "evictions")
         registry.registerAll(GuavaCacheMetrics.metricsFor(GuavaCacheMetricsTest.class, "MyCache", cache))
 
         when: "various read/write operations are performed on the cache"
@@ -37,10 +38,10 @@ class GuavaCacheMetricsTest extends Specification {
 
         def gauges = registry.gauges
 
-        2   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.hitCount"].value
-        3   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.missCount"].value
-        0.4 == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.hitRate"].value
-        1   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.loadExceptionCount"].value
-        0   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.evictionCount"].value
+        2   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.hits"].value
+        3   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.misses"].value
+        0.4 == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.efficiency"].value
+        1   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.loadExceptions"].value
+        0   == gauges["no.finn.metrics.GuavaCacheMetricsTest.MyCache.evictions"].value
     }
 }


### PR DESCRIPTION
Hi.

In our project we have somewhat different scheme of metrics naming, for example "hit.count" instead of "hitCount".

Would you mind including such change? Note that I am new to Java so this PR might need further work - just let me know.

Best regards,
Alexey Nezhdanov