### PR TITLE
Metric for cache size

### DIFF
--- a/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
+++ b/src/main/java/no/finn/metrics/GuavaCacheMetrics.java
@@ -69,6 +69,13 @@ public class GuavaCacheMetrics extends HashMap< String, Metric> implements Metri
             }
         } );
 
+        metrics.put( name( clzz, cacheName, "size" ), new Gauge< Long >() {
+            @Override
+            public Long getValue() {
+                return cache.size();
+            }
+        } );
+
         return metrics;
     }
 


### PR DESCRIPTION
I use `guava-metrics`a lot, but often find myself adding a metric for cache size. What do you think about including that as a built-in metric?